### PR TITLE
EP-59:  Updating dependencies.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1.7.0
+      uses: aws-actions/configure-aws-credentials@v5.0.0
       with:
         aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
@@ -44,14 +44,14 @@ runs:
 
     - name: Fill in the new image ID in the Amazon ECS task definition
       id: task-def
-      uses: aws-actions/amazon-ecs-render-task-definition@v1.1.2
+      uses: aws-actions/amazon-ecs-render-task-definition@v1.8.0
       with:
         task-definition: task-definition.json
         container-name: ${{ inputs.container-name }}
         image: ${{ inputs.docker-image }}
 
     - name: Deploy Amazon ECS task definition
-      uses: aws-actions/amazon-ecs-deploy-task-definition@v1.4.10
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v2.3.4
       with:
         task-definition: ${{ steps.task-def.outputs.task-definition }}
         service: ${{ inputs.ecs-service }}


### PR DESCRIPTION
## Issue ticket number and link
[EP-59](https://lcvista.atlassian.net/browse/EP-59)

## Updated Dependencies

### 1. aws-actions/configure-aws-credentials
- **From:** v1.7.0
- **To:** v5.0.0
- **Type:** Major version upgrade
- **Key Changes:**
  - ⚠️ **Breaking Change:** Boolean input handling improvements
  - Added skip OIDC option
  - Added account ID allowlist support
  - Multiple bug fixes and security improvements
  - **Impact:** The boolean inputs we use (`wait-for-service-stability`) should continue to work normally

### 2. aws-actions/amazon-ecs-render-task-definition
- **From:** v1.1.2
- **To:** v1.8.0
- **Type:** Minor version upgrade
- **Key Changes:**
  - Multiple bug fixes
  - Improved task definition rendering
  - Better error handling
  - **Impact:** Fully backward compatible

### 3. aws-actions/amazon-ecs-deploy-task-definition
- **From:** v1.4.10
- **To:** v2.3.4
- **Type:** Major version upgrade
- **Key Changes:**
  - Upgraded to AWS SDK v3
  - Added support for ad-hoc task runs
  - Added CodeDeploy deployment config name parameter
  - Added AWS managed tags support
  - Added service and task tagging
  - **Impact:** Backward compatible for our use case

## Compatibility Assessment

✅ **All updates are compatible** with the current action configuration:

1. **Input parameters remain unchanged** - All inputs we use (`aws-region`, `ecs-cluster`, `ecs-service`, etc.) are still supported
2. **Output parameters remain consistent** - The task definition output structure is maintained
3. **Workflow logic unchanged** - The sequence of steps and their interactions remain the same

## Benefits of Updates

- **Security improvements** across all actions
- **Better error handling** and debugging capabilities
- **Performance enhancements** with AWS SDK v3
- **New features available** for future enhancements (tags, CodeDeploy support, etc.)
- **Long-term support** with latest maintained versions

## Rollback Plan

If issues arise, you can easily rollback by reverting the version numbers in `action.yml`:
- `aws-actions/configure-aws-credentials@v1.7.0`
- `aws-actions/amazon-ecs-render-task-definition@v1.1.2` 
- `aws-actions/amazon-ecs-deploy-task-definition@v1.4.10`

## Testing Checklist

- [x] **Test in development environment first** before applying to production
- [x] **Verify boolean input handling** - Ensure `wait-for-service-stability` input works as expected
- [x] **Monitor deployment logs** for any new warnings or changes in behavior
- [x] **Validate task definition rendering** and ECS service updates work correctly

[EP-59]: https://lcvista.atlassian.net/browse/EP-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ